### PR TITLE
Stable binary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,63 +2,55 @@ name: CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [ "**" ]
   pull_request:
-    branches: [ main ]
+    branches: [ "**" ]
 
 jobs:
-  test:
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest]
-        go-version: [1.21.x]
-        include:
-          - os: ubuntu-latest
-            compiler: gcc
-          - os: ubuntu-latest
-            compiler: clang
-          - os: macos-latest
-            compiler: clang
-
-    runs-on: ${{ matrix.os }}
-
+  build-and-test:
+    runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+      - name: Checkout Repository
+        uses: actions/checkout@v4
 
-    - name: Set up Go
-      uses: actions/setup-go@v5
-      with:
-        go-version: ${{ matrix.go-version }}
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.23'
 
-    - name: Install dependencies
-      run: go mod download
+      - name: Cache Dependencies
+        uses: actions/cache@v3
+        id: gomod-cache
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('go.mod') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
 
-    - name: Format Check
-      run: |
-        check_format() {
-            unformatted=$(go fmt ./...)
-            if [ -n "$unformatted" ]; then
-            echo "The following files are not formatted in $1:"
+      - name: Install Dependencies
+        run: go mod tidy
+
+      - name: Lint
+        run: |
+          go install golang.org/x/lint/golint@latest
+          golint ./...
+
+      - name: Format Check
+        run: |
+          unformatted=$(go fmt ./...)
+          if [ -n "$unformatted" ]; then
+            echo "The following files are not formatted:"
             echo "$unformatted"
-            return 1
-            fi
-            echo "Code is formatted in $1."
-            return 0
-        }
-        
-        cd compiler && check_format "compiler"
+            exit 1
+          else
+            echo "Code is formatted."
+          fi
 
-    - name: Run tests
-      env:
-        GOOS: ${{ matrix.os == 'windows-latest' && 'windows' || matrix.os == 'macos-latest' && 'darwin' || 'linux' }}
-        COMPILER: ${{ matrix.compiler }}
-      run: go test -v ./...
+      - name: Vet
+        run: go vet ./...
 
-    - name: Build
-      run: go build -v ./...
+      - name: Build
+        run: go build -v ./...
 
-    - name: Run linter
-      uses: golangci/golangci-lint-action@v4
-      with:
-        version: latest
-        args: --timeout=5m 
+      - name: Test
+        run: go test -v ./...

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
           for platform in "${PLATFORMS[@]}"; do
             OS=${platform%/*}
             ARCH=${platform#*/}
-            output_name="releases/tinyass-${OS}-${ARCH}"
+            output_name="releases/cp2p-${OS}-${ARCH}"
             if [ $OS = "windows" ]; then
               output_name="$output_name.exe"
             fi


### PR DESCRIPTION
This pull request includes significant updates to the CI and release workflows, primarily focusing on broadening the scope of branches for CI triggers and simplifying the CI job steps.

### CI Workflow Updates:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL5-R56): The CI workflow now triggers on all branches instead of just the `main` branch. Additionally, the job matrix strategy has been replaced with a single `build-and-test` job that runs on `ubuntu-latest`. The steps within this job have been streamlined to include repository checkout, Go setup, dependency caching, installation, linting, formatting, vetting, building, and testing.

### Release Workflow Updates:

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L37-R37): The output name for releases has been updated from `tinyass` to `cp2p` for all platforms.