### PR TITLE
Update GitHub Actions workflow to downgrade Go version to 1.21 and ch…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.23'
+          go-version: '1.21'
 
       - name: Build for Multiple Platforms
         run: |
@@ -38,7 +38,7 @@ jobs:
             if [ $OS = "windows" ]; then
               output_name="$output_name.exe"
             fi
-            GOOS=$OS GOARCH=$ARCH go build -o "$output_name" .
+            GOOS=$OS GOARCH=$ARCH go build -o "$output_name" ./cmd/cpp2py
           done
 
       - name: Generate Next Version


### PR DESCRIPTION
This pull request includes updates to the Go setup and build process in the GitHub Actions workflow for releases. The most important changes are:

* Updated the Go version from `1.23` to `1.21` in the setup step. (`.github/workflows/release.yml` [.github/workflows/release.ymlL28-R28](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L28-R28))
* Modified the build command to specify the `./cmd/cpp2py` directory, ensuring the correct build path is used. (`.github/workflows/release.yml` [.github/workflows/release.ymlL41-R41](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L41-R41))